### PR TITLE
Fix command line format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Embedding is done in 2 basic steps: graph construction and training.
 
 Let's assume that the basic configuration of the program looks like this:
     
-    --input files/samples/edgelist_2.tsv --columns users complex::products complex::brands --dimension 3 --number-of-iterations 4
+    --input files/samples/edgelist_2.tsv --columns="users complex::products complex::brands" --dimension 3 --number-of-iterations 4
 
 Every SparseMatrix is created based on the program argument `--columns`. For our example, there will be three SparseMatrix'es that will only read data from the columns:
 - users and brands by M1


### PR DESCRIPTION
One of the examples in the README had a slightly malformed command line.