### PR TITLE
Use closing channel to communicate end-of-work instead of magic value

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -179,7 +179,7 @@ where
     }
 
     #[inline(always)]
-    fn update_entity_mapping(&mut self, entity: &str, hash: u64, column: &Column) {
+    fn update_entity_mapping(&self, entity: &str, hash: u64, column: &Column) {
         if !column.transient && !self.entity_mapping_persistor.contains(hash) {
             let entry = if self.config.prepend_field {
                 let mut entry = column.name.clone();
@@ -229,11 +229,6 @@ where
             }
             arr
         })
-    }
-
-    pub fn finish(&mut self) {
-        let end_vec = vec![0u64];
-        (self.hashes_handler)(SmallVec::from_vec(end_vec));
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -30,37 +30,34 @@ pub fn build_graphs(
         let rx = bus.add_rx();
         let handle = thread::spawn(move || {
             for received in rx {
-                if received[0] != 0 {
-                    sparse_matrix.handle_pair(&received);
-                } else {
-                    sparse_matrix.finish();
-                    break;
-                }
+                sparse_matrix.handle_pair(&received);
             }
+            sparse_matrix.finish();
             sparse_matrix
         });
         sparse_matrix_threads.push(handle);
     }
 
-    let mut entity_processor =
-        EntityProcessor::new(config, in_memory_entity_mapping_persistor, |hashes| {
-            bus.broadcast(hashes);
-        });
+    for input in config.input.iter() {
+        let mut entity_processor = EntityProcessor::new(
+            config,
+            in_memory_entity_mapping_persistor.clone(),
+            |hashes| {
+                bus.broadcast(hashes);
+            },
+        );
 
-    match &config.file_type {
-        FileType::Json => {
-            let mut parser = dom::Parser::default();
-            for input in config.input.iter() {
-                read_file(input, config.log_every_n as u64, |line| {
+        match &config.file_type {
+            FileType::Json => {
+                let mut parser = dom::Parser::default();
+                read_file(input, config.log_every_n as u64, move |line| {
                     let row = parse_json_line(line, &mut parser, &config.columns);
                     entity_processor.process_row(&row);
                 });
             }
-        }
-        FileType::Tsv => {
-            let config_col_num = config.columns.len();
-            for input in config.input.iter() {
-                read_file(input, config.log_every_n as u64, |line| {
+            FileType::Tsv => {
+                let config_col_num = config.columns.len();
+                read_file(input, config.log_every_n as u64, move |line| {
                     let row = parse_tsv_line(line);
                     let line_col_num = row.len();
                     if line_col_num == config_col_num {
@@ -73,7 +70,7 @@ pub fn build_graphs(
         }
     }
 
-    entity_processor.finish();
+    drop(bus);
 
     let mut sparse_matrices = vec![];
     for join_handle in sparse_matrix_threads {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -214,7 +214,7 @@ pub fn train(
     }
 
     for join_handle in embedding_threads {
-        let _ = join_handle
+        join_handle
             .join()
             .expect("Couldn't join on the associated thread");
     }


### PR DESCRIPTION
It was possible to generate end-of-work token from legitimate data.
After this change its no longer the case